### PR TITLE
Feature: new ftp-post-sync-commands option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is a composite GitHub Action (Linux runner) for deploying repository conten
 - Uses [composite action](https://docs.github.com/en/actions/creating-actions/about-actions#types-of-actions) without Docker container for faster deployments and shorter run time
 - Pass additional command arguments to SSH and FTP client for custom configurations and settings
 - Step runs messages categorized nicely in log groups
-- Post FTP commands after synchronization
+- Run additional FTP commands after synchronization
 
 ![Workflow screenshot](./screenshot.png)
 
@@ -96,10 +96,10 @@ jobs:
 | ssh-options            | no                   |         | Additional arguments for SSH client           |
 | ftp-options            | no                   |         | Additional arguments for FTP client           |
 | ftp-mirror-options     | no                   |         | Additional arguments for mirroring            |
-| ftp-post-sync-commands | no                   | false   | Additionnal FTP command to run after sync     |
+| ftp-post-sync-commands | no                   |         | Additionnal FTP command to run after sync     |
 | webhook                | no                   |         | Send webhook event notifications              |
 | artifacts              | no                   | false   | Upload logs/files to artifacts (true, false)  |
-| debug                  | no                   |         | Enable debug information (true, false)        |
+| debug                  | no                   | false   | Enable debug information (true, false)        |
 
 ### Notes
 
@@ -114,6 +114,14 @@ jobs:
     - Does not delete files on remote host
     - Default glob exclude pattern is `.git*/`
 - For `ftp-options` and `ftp-mirror-options` command arguments please refer to [LFTP manual](https://lftp.yar.ru/lftp-man.html)
+- `ftp-post-sync-commands` can be used to run additional LFTP commands after the
+    synchronization. For example, to upload a file watched by a process manager
+    on the server in order to restart a deamon:
+    ```
+    ftp-post-sync-commands: |
+      !touch watched_file
+      put watched_file
+    ```
 - Setting `webhook` to a URL will send start and finish event notifications in JSON format
   - start event payload:
   ```

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This is a composite GitHub Action (Linux runner) for deploying repository conten
 - Uses [composite action](https://docs.github.com/en/actions/creating-actions/about-actions#types-of-actions) without Docker container for faster deployments and shorter run time
 - Pass additional command arguments to SSH and FTP client for custom configurations and settings
 - Step runs messages categorized nicely in log groups
+- Post FTP commands after synchronization
 
 ![Workflow screenshot](./screenshot.png)
 
@@ -75,29 +76,30 @@ jobs:
 
 ## Inputs
 
-| Name                  | Required             | Default | Description                                   |
-|-----------------------|----------------------|---------|-----------------------------------------------|
-| remote-protocol       | yes                  | sftp    | Remote file transfer protocol (ftp, sftp)     |
-| remote-host           | yes                  |         | Remote host                                   |
-| remote-port           | yes                  | 22      | Remote port                                   |
-| remote-user           | yes                  |         | FTP/SSH username                              |
-| remote-password       | no                   |         | FTP/SSH password                              |
-| ssh-private-key       | no                   |         | SSH private key of user                       |
-| proxy                 | yes                  | false   | Enable proxy for FTP connection (true, false) |
-| proxy-host            | yes (if proxy: true) |         | Proxy host                                    |
-| proxy-port            | yes (if proxy: true) | 22      | Proxy port                                    |
-| proxy-forwarding-port | yes (if proxy: true) | 1080    | Proxy forwarding port                         |
-| proxy-user            | yes (if proxy: true) |         | Proxy username                                |
-| proxy-private-key     | yes (if proxy: true) |         | Proxy SSH private key of user                 |
-| local-path            | yes                  | .       | Local path to repository                      |
-| remote-path           | yes                  | .       | Remote path on host                           |
-| sync                  | yes                  | delta   | File synchronization (delta, full)            |
-| ssh-options           | no                   |         | Additional arguments for SSH client           |
-| ftp-options           | no                   |         | Additional arguments for FTP client           |
-| ftp-mirror-options    | no                   |         | Additional arguments for mirroring            |
-| webhook               | no                   |         | Send webhook event notifications              |
-| artifacts             | no                   | false   | Upload logs/files to artifacts (true, false)  |
-| debug                 | no                   | false   | Enable debug information (true, false)        |
+| Name                   | Required             | Default | Description                                   |
+|------------------------|----------------------|---------|-----------------------------------------------|
+| remote-protocol        | yes                  | sftp    | Remote file transfer protocol (ftp, sftp)     |
+| remote-host            | yes                  |         | Remote host                                   |
+| remote-port            | yes                  | 22      | Remote port                                   |
+| remote-user            | yes                  |         | FTP/SSH username                              |
+| remote-password        | no                   |         | FTP/SSH password                              |
+| ssh-private-key        | no                   |         | SSH private key of user                       |
+| proxy                  | yes                  | false   | Enable proxy for FTP connection (true, false) |
+| proxy-host             | yes (if proxy: true) |         | Proxy host                                    |
+| proxy-port             | yes (if proxy: true) | 22      | Proxy port                                    |
+| proxy-forwarding-port  | yes (if proxy: true) | 1080    | Proxy forwarding port                         |
+| proxy-user             | yes (if proxy: true) |         | Proxy username                                |
+| proxy-private-key      | yes (if proxy: true) |         | Proxy SSH private key of user                 |
+| local-path             | yes                  | .       | Local path to repository                      |
+| remote-path            | yes                  | .       | Remote path on host                           |
+| sync                   | yes                  | delta   | File synchronization (delta, full)            |
+| ssh-options            | no                   |         | Additional arguments for SSH client           |
+| ftp-options            | no                   |         | Additional arguments for FTP client           |
+| ftp-mirror-options     | no                   |         | Additional arguments for mirroring            |
+| ftp-post-sync-commands | no                   | false   | Additionnal FTP command to run after sync     |
+| webhook                | no                   |         | Send webhook event notifications              |
+| artifacts              | no                   | false   | Upload logs/files to artifacts (true, false)  |
+| debug                  | no                   |         | Enable debug information (true, false)        |
 
 ### Notes
 

--- a/action.yml
+++ b/action.yml
@@ -70,6 +70,9 @@ inputs:
   ftp-mirror-options:
     description: "Additional command arguments for mirroring (lftp)"
     required: false
+  ftp-post-sync-commands:
+    description: "Additional ftp commands to run after synchronization (lftp)"
+    required: false
   webhook:
     description: "Send webhook event notifications"
     required: false
@@ -162,9 +165,9 @@ runs:
           echo "::group::Debug"
 
           echo "Context: github.event" && cat ${{github.event_path}} && show_hr
-          
+
           echo "Context: env" && echo "${{toJSON(env)}}" && show_hr
-          
+
           echo "Inputs:" && echo "${{toJSON(inputs)}}"
 
           echo "::endgroup::"
@@ -341,12 +344,14 @@ runs:
         if [ "${input_sync}" == "full" ]; then
           ${proxy_cmd} lftp -c "put -O \"${remote_path_unslash}\" .deploy-running
             mirror --exclude-glob=.git*/ --max-errors=10 --reverse ${{inputs.ftp-mirror-options}} ${{inputs.local-path}} ${remote_path_unslash}
-            rm -f \"${remote_path_slash}.deploy-running\""
+            rm -f \"${remote_path_slash}.deploy-running\"
+            ${{inputs.ftp-post-sync-commands}}"
         else
           ${proxy_cmd} lftp -c "put -O \"${remote_path_unslash}\" .deploy-running
             mput -d -O \"${remote_path_unslash}\" .deploy-revision $(awk 'ORS=" " { print "\"" $0 "\"" }' ~/files_to_upload)
             rm -f \"${remote_path_slash}.deploy-check\" $(awk 'ORS=" " { print "\"${remote_path_slash}" $0 "\"" }' ~/files_to_delete)
-            rm -f \"${remote_path_slash}.deploy-running\""
+            rm -f \"${remote_path_slash}.deploy-running\"
+            ${{inputs.ftp-post-sync-commands}}"
         fi
 
         [ -f ~/transfer_log.txt ] && cat ~/transfer_log.txt


### PR DESCRIPTION
Here is an additional `ftp-post-sync-commands` input parameter allowing to specify a list of arbitrary LFTP commands run after the synchronization.