### PR TITLE
delete remote files/folders when syncing using the mirror command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -343,7 +343,7 @@ runs:
 
         if [ "${input_sync}" == "full" ]; then
           ${proxy_cmd} lftp -c "put -O \"${remote_path_unslash}\" .deploy-running
-            mirror --exclude-glob=.git*/ --max-errors=10 --reverse ${{inputs.ftp-mirror-options}} ${{inputs.local-path}} ${remote_path_unslash}
+            mirror --exclude-glob=.git*/ --max-errors=10 --reverse --delete ${{inputs.ftp-mirror-options}} ${{inputs.local-path}} ${remote_path_unslash}
             rm -f \"${remote_path_slash}.deploy-running\"
             ${{inputs.ftp-post-sync-commands}}"
         else


### PR DESCRIPTION
### Problem:
- In full sync mode; files/folders removed from my directory aren't deleted on the server.

### Solution:
- Added the delete flag to the lftp mirror command used for full sync.

### Additional Context:
- Not sure why this is omitted but if this is problematic could we add an input to make adding this flag and option?