### PR TITLE
fix: prefix local path to `.deploy-running`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -355,13 +355,13 @@ runs:
         touch "${local_path_slash}.deploy-running"
 
         if [ "${input_sync}" == "full" ]; then
-          ${proxy_cmd} lftp -c "put -O \"${remote_path_unslash}\" .deploy-running;
+          ${proxy_cmd} lftp -c "put -O \"${remote_path_unslash}\" \"${local_path_slash}.deploy-running\";
             mirror --exclude-glob=.git*/ --max-errors=10 --reverse ${{inputs.ftp-mirror-options}} ${local_path_unslash} ${remote_path_unslash};
             rm -f \"${remote_path_slash}.deploy-running\";
             ${{inputs.ftp-post-sync-commands}}"
         else
           ${proxy_cmd} lftp -c "lcd \"${local_path_unslash}\";
-            put -O \"${remote_path_unslash}\" .deploy-running;
+            put -O \"${remote_path_unslash}\" \"${local_path_slash}.deploy-running\";
             mput -d -O \"${remote_path_unslash}\" .deploy-revision $(awk '{ printf "\"%s\" ", $0 }' ~/files_to_upload);
             rm -f \"${remote_path_slash}.deploy-check\" $(awk -v REMOTEPATH=\"${remote_path_slash}\" '{ printf "\"%s%s\" ", REMOTEPATH, $0 }' ~/files_to_delete);
             rm -f \"${remote_path_slash}.deploy-running\";


### PR DESCRIPTION
Fixes https://github.com/milanmk/actions-file-deployer/issues/28

## Problem

When using a local path that isn't `.`, the action fails because it cannot find the local `.deploy-running` file:

```
Transfer files
  Protocol: sftp
  Synchronization: full
  Local path: asset
  Remote path: /asset
  ____________________________________________________________________________________________________
  put: /home/runner/work/[repo]/[checked-out-repo]/.deploy-running: No such file or directory
  Error: Process completed with exit code 1.
```

Notice that the path did not contain `asset`.

## Changes

Prefix with `${local_path_slash}` when doing the `put` command.

When testing this out the action succeeded with the logs:

```
Transfer files
  Protocol: sftp
  Synchronization: full
  Local path: ./asset
  Remote path: /asset
  ____________________________________________________________________________________________________
  /home/runner/work/[repo]/[checked-out-repo]/asset/.deploy-running -> etc...
```