### PR TITLE
Added option of sync-delta-includes to allow adding files which are added through a build process in the workflow. 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -331,7 +331,7 @@ runs:
             echo ${{inputs.sync-delta-includes}}
             # ${{inputs.sync-delta-includes}} >> ~/files_to_upload
             for pattern in ${{inputs.sync-delta-includes}}; do
-                find . -path "$pattern" -type f >> ~/files_to_upload
+                find . -path "$pattern/**" -type f >> ~/files_to_upload
             done
             
             sed --in-place --regexp-extended "s#(.*)#realpath --canonicalize-missing --relative-to=$local_path_unslash \1#e" ~/files_to_upload

--- a/action.yml
+++ b/action.yml
@@ -323,7 +323,7 @@ runs:
           # show_hr
 
           if git cat-file -t ${git_previous_commit} &>/dev/null; then
-            git diff --diff-filter=ACMRT --name-only ${git_previous_commit}..${{github.sha}} -- ${local_path_unslash} ${{inputs.sync-delta-includes}} ':!/.git*' ${{inputs.sync-delta-excludes}} > ~/files_to_upload
+            git diff --diff-filter=ACMRT --name-only ${git_previous_commit}..${{github.sha}} -- ${local_path_unslash} ':!/.git*' ${{inputs.sync-delta-excludes}} > ~/files_to_upload
             git diff-tree --diff-filter=D --name-only -t ${git_previous_commit}..${{github.sha}} -- ${local_path_unslash} ':!/.git*' ${{inputs.sync-delta-excludes}} > ~/files_to_delete
 
             # Assuming inputs.sync-delta-includes is a space-separated list of patterns

--- a/action.yml
+++ b/action.yml
@@ -331,7 +331,8 @@ runs:
             echo ${{inputs.sync-delta-includes}}
             # ${{inputs.sync-delta-includes}} >> ~/files_to_upload
             for pattern in ${{inputs.sync-delta-includes}}; do
-                find . -path "$pattern/**" -type f >> ~/files_to_upload
+              echo "shishir 123 "
+              find . -path "$pattern/**" -type f >> ~/files_to_upload
             done
             
             sed --in-place --regexp-extended "s#(.*)#realpath --canonicalize-missing --relative-to=$local_path_unslash \1#e" ~/files_to_upload

--- a/action.yml
+++ b/action.yml
@@ -329,7 +329,7 @@ runs:
             # Assuming inputs.sync-delta-includes is a space-separated list of patterns
             echo "shishir "
             echo ${{inputs.sync-delta-includes}}
-            ${{inputs.sync-delta-includes}} >> ~/files_to_upload
+            # ${{inputs.sync-delta-includes}} >> ~/files_to_upload
             for pattern in ${{inputs.sync-delta-includes}}; do
                 find . -path "$pattern" -type f >> ~/files_to_upload
             done

--- a/action.yml
+++ b/action.yml
@@ -326,15 +326,18 @@ runs:
             git diff --diff-filter=ACMRT --name-only ${git_previous_commit}..${{github.sha}} -- ${local_path_unslash} ${{inputs.sync-delta-includes}} ':!/.git*' ${{inputs.sync-delta-excludes}} > ~/files_to_upload
             git diff-tree --diff-filter=D --name-only -t ${git_previous_commit}..${{github.sha}} -- ${local_path_unslash} ':!/.git*' ${{inputs.sync-delta-excludes}} > ~/files_to_delete
 
-            sed --in-place --regexp-extended "s#(.*)#realpath --canonicalize-missing --relative-to=$local_path_unslash \1#e" ~/files_to_upload
-            sed --in-place --regexp-extended "s#(.*)#realpath --canonicalize-missing --relative-to=$local_path_unslash \1#e" ~/files_to_delete
-
             # Assuming inputs.sync-delta-includes is a space-separated list of patterns
             echo "shishir "
             echo ${{inputs.sync-delta-includes}}
+            ${{inputs.sync-delta-includes}} >> ~/files_to_upload
             for pattern in ${{inputs.sync-delta-includes}}; do
                 find . -path "$pattern" -type f >> ~/files_to_upload
             done
+            
+            sed --in-place --regexp-extended "s#(.*)#realpath --canonicalize-missing --relative-to=$local_path_unslash \1#e" ~/files_to_upload
+            sed --in-place --regexp-extended "s#(.*)#realpath --canonicalize-missing --relative-to=$local_path_unslash \1#e" ~/files_to_delete
+
+            
 
             echo "File created: ~/files_to_upload" && cat ~/files_to_upload && show_hr
             echo "File created: ~/files_to_delete" && cat ~/files_to_delete && show_hr

--- a/action.yml
+++ b/action.yml
@@ -327,11 +327,8 @@ runs:
             git diff-tree --diff-filter=D --name-only -t ${git_previous_commit}..${{github.sha}} -- ${local_path_unslash} ':!/.git*' ${{inputs.sync-delta-excludes}} > ~/files_to_delete
 
             # Assuming inputs.sync-delta-includes is a space-separated list of patterns
-            echo "shishir "
-            echo ${{inputs.sync-delta-includes}}
             # ${{inputs.sync-delta-includes}} >> ~/files_to_upload
             for pattern in ${{inputs.sync-delta-includes}}; do
-              echo "shishir 123 "
               find "$pattern" -type f >> ~/files_to_upload
             done
             

--- a/action.yml
+++ b/action.yml
@@ -329,6 +329,11 @@ runs:
             sed --in-place --regexp-extended "s#(.*)#realpath --canonicalize-missing --relative-to=$local_path_unslash \1#e" ~/files_to_upload
             sed --in-place --regexp-extended "s#(.*)#realpath --canonicalize-missing --relative-to=$local_path_unslash \1#e" ~/files_to_delete
 
+            # Assuming inputs.sync-delta-includes is a space-separated list of patterns
+            for pattern in ${{inputs.sync-delta-includes}}; do
+                find . -path "$pattern" -type f >> ~/files_to_upload
+            done
+
             echo "File created: ~/files_to_upload" && cat ~/files_to_upload && show_hr
             echo "File created: ~/files_to_delete" && cat ~/files_to_delete && show_hr
 

--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,9 @@ inputs:
   sync-delta-excludes:
     description: "Files to exclude from delta sync"
     required: false
+  sync-delta-includes:
+    description: "Files to include into delta sync"
+    required: false
   ssh-options:
     description: "Additional command arguments for SSH client"
     required: false
@@ -320,7 +323,7 @@ runs:
           # show_hr
 
           if git cat-file -t ${git_previous_commit} &>/dev/null; then
-            git diff --diff-filter=ACMRT --name-only ${git_previous_commit}..${{github.sha}} -- ${local_path_unslash} ':!/.git*' ${{inputs.sync-delta-excludes}} > ~/files_to_upload
+            git diff --diff-filter=ACMRT --name-only ${git_previous_commit}..${{github.sha}} -- ${local_path_unslash} ${{inputs.sync-delta-includes}} ':!/.git*' ${{inputs.sync-delta-excludes}} > ~/files_to_upload
             git diff-tree --diff-filter=D --name-only -t ${git_previous_commit}..${{github.sha}} -- ${local_path_unslash} ':!/.git*' ${{inputs.sync-delta-excludes}} > ~/files_to_delete
 
             sed --in-place --regexp-extended "s#(.*)#realpath --canonicalize-missing --relative-to=$local_path_unslash \1#e" ~/files_to_upload

--- a/action.yml
+++ b/action.yml
@@ -332,7 +332,7 @@ runs:
             # ${{inputs.sync-delta-includes}} >> ~/files_to_upload
             for pattern in ${{inputs.sync-delta-includes}}; do
               echo "shishir 123 "
-              find . -path "$pattern/**" -type f >> ~/files_to_upload
+              find "$pattern" -type f >> ~/files_to_upload
             done
             
             sed --in-place --regexp-extended "s#(.*)#realpath --canonicalize-missing --relative-to=$local_path_unslash \1#e" ~/files_to_upload

--- a/action.yml
+++ b/action.yml
@@ -330,6 +330,8 @@ runs:
             sed --in-place --regexp-extended "s#(.*)#realpath --canonicalize-missing --relative-to=$local_path_unslash \1#e" ~/files_to_delete
 
             # Assuming inputs.sync-delta-includes is a space-separated list of patterns
+            echo "shishir "
+            echo ${{inputs.sync-delta-includes}}
             for pattern in ${{inputs.sync-delta-includes}}; do
                 find . -path "$pattern" -type f >> ~/files_to_upload
             done


### PR DESCRIPTION
Here is an example of how I configured it on the fork. 

```
on: push
name: 🚀 Deploy on on teampro New new
jobs:
  deploy-master:
    name: "Deploy on on teampro New new "
    runs-on: ubuntu-latest
    timeout-minutes: 30
    steps:
      - name: Checkout Repository
        uses: actions/checkout@v4
        with:
          fetch-depth: 0

      - name: 🔨 Build Project
        run: |
          cd todo/teamprotodo_vue/
          npm install
          npm run build
          cd ../../
      - name: Deploy Files
        uses: shishirraven/actions-file-deployer@master
        with:
          sync-delta-includes: '~/work/teamstream_webfort/teamstream_webfort/todo/teamprotodo_vue/dist '
          remote-protocol: "sftp"
          remote-host: ${{ secrets.DEPLOY_HOST }}
          remote-user: ${{ secrets.DEPLOY_USER }}
          ssh-private-key: ${{ secrets.DEPLOY_PRIVATE_KEY }}
          remote-path: "/home/bitnami/htdocs/teampro/new2"
```