### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -147,7 +147,7 @@ runs:
         fi
 
         input_sync=${{inputs.sync}}
-        if [ "${{github.event_name}}" == "workflow_dispatch" ]; then
+        if [ "${{github.event_name}}" == "workflow_dispatch" ] && [ -n "${{github.event.inputs.sync}}" ]; then
           input_sync=${{github.event.inputs.sync}}
         fi
 


### PR DESCRIPTION
You're assuming in a hardcoded way that there's a `sync` input available when `workflow_dispatch` is present.
If it's not, `input_sync` will always become empty. Let's avoid that.